### PR TITLE
fix: CLI now reads time_expansion_factor correctly

### DIFF
--- a/batdetect2/cli.py
+++ b/batdetect2/cli.py
@@ -77,6 +77,7 @@ def detect(
     audio_dir: str,
     ann_dir: str,
     detection_threshold: float,
+    time_expansion_factor: int,
     **args,
 ):
     """Detect bat calls in files in AUDIO_DIR and save predictions to ANN_DIR.
@@ -103,6 +104,7 @@ def detect(
         **{
             **params,
             **args,
+            'time_expansion': time_expansion_factor,
             "spec_slices": False,
             "chunk_size": 2,
             "detection_threshold": detection_threshold,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,3 +42,28 @@ def test_cli_detect_command_on_test_audio(tmp_path):
     assert results_dir.exists()
     assert len(list(results_dir.glob("*.csv"))) == 3
     assert len(list(results_dir.glob("*.json"))) == 3
+
+
+def test_cli_detect_command_with_non_trivial_time_expansion(tmp_path):
+    """Test the detect command with a non-trivial time expansion factor."""
+    results_dir = tmp_path / "results"
+
+    # Remove results dir if it exists
+    if results_dir.exists():
+        results_dir.rmdir()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "detect",
+            "example_data/audio",
+            str(results_dir),
+            "0.3",
+            "--time_expansion_factor",
+            "10",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert 'time_exp_fact 10' in result.stdout


### PR DESCRIPTION
Changes:

1. Added a test case to make sure the time_expansion_factor argument for the CLI command is being used.
2. Fixed parameter loading in the CLI detect function.