### PR TITLE
fix: Handle Empty Audio Files Gracefully (GH-20)

### DIFF
--- a/batdetect2/cli.py
+++ b/batdetect2/cli.py
@@ -1,4 +1,5 @@
 """BatDetect2 command line interface."""
+
 import os
 
 import click
@@ -129,10 +130,9 @@ def detect(
             ):
                 results_path = audio_file.replace(audio_dir, ann_dir)
                 save_results_to_file(results, results_path)
-        except (RuntimeError, ValueError, LookupError) as err:
+        except (RuntimeError, ValueError, LookupError, EOFError) as err:
             error_files.append(audio_file)
-            click.secho(f"Error processing file!: {err}", fg="red")
-            raise err
+            click.secho(f"Error processing file {audio_file}: {err}", fg="red")
 
     click.echo(f"\nResults saved to: {ann_dir}")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,10 +7,11 @@ from click.testing import CliRunner
 
 from batdetect2.cli import cli
 
+runner = CliRunner()
+
 
 def test_cli_base_command():
     """Test the base command."""
-    runner = CliRunner()
     result = runner.invoke(cli, ["--help"])
     assert result.exit_code == 0
     assert (
@@ -20,7 +21,6 @@ def test_cli_base_command():
 
 def test_cli_detect_command_help():
     """Test the detect command help."""
-    runner = CliRunner()
     result = runner.invoke(cli, ["detect", "--help"])
     assert result.exit_code == 0
     assert "Detect bat calls in files in AUDIO_DIR" in result.output
@@ -34,7 +34,6 @@ def test_cli_detect_command_on_test_audio(tmp_path):
     if results_dir.exists():
         results_dir.rmdir()
 
-    runner = CliRunner()
     result = runner.invoke(
         cli,
         [
@@ -58,7 +57,6 @@ def test_cli_detect_command_with_non_trivial_time_expansion(tmp_path):
     if results_dir.exists():
         results_dir.rmdir()
 
-    runner = CliRunner()
     result = runner.invoke(
         cli,
         [
@@ -83,7 +81,6 @@ def test_cli_detect_command_with_the_spec_feature_flag(tmp_path: Path):
     if results_dir.exists():
         results_dir.rmdir()
 
-    runner = CliRunner()
     result = runner.invoke(
         cli,
         [
@@ -110,3 +107,26 @@ def test_cli_detect_command_with_the_spec_feature_flag(tmp_path: Path):
 
         df = pd.read_csv(results_dir / expected_file)
         assert not (df.duration == -1).any()
+
+
+def test_cli_detect_fails_gracefully_on_empty_file(tmp_path: Path):
+    results_dir = tmp_path / "results"
+    target = tmp_path / "audio"
+    target.mkdir()
+
+    # Create an empty file with the .wav extension
+    empty_file = target / "empty.wav"
+    empty_file.touch()
+
+    result = runner.invoke(
+        cli,
+        args=[
+            "detect",
+            str(target),
+            str(results_dir),
+            "0.3",
+            "--spec_features",
+        ],
+    )
+    assert result.exit_code == 0
+    assert f"Error processing file {empty_file}" in result.output


### PR DESCRIPTION
This PR addresses issue #20, where the `batdetect` CLI encountered errors when processing empty audio files. This scenario is common with AudioMoth devices experiencing low battery, as they may generate empty recordings.

To prevent a single empty file from halting the entire `detect` command:

* **Improved error handling:** Added `EOFError` to the list of expected exceptions when reading audio file metadata. This error occurs when attempting to determine the sample rate of an empty file.
* **Better user feedback:** The `detect` command now gracefully handles empty files, adding them to the list of problematic files and reporting them to the user upon completion.
* **Added test case:** Created a new test case that specifically runs the `detect` command on an empty file, ensuring it no longer causes a failure.

**Acknowledgments:**

Thanks to @EvansMike for reporting this issue and providing valuable feedback.