### PR TITLE
Http support

### DIFF
--- a/batdetect2/api.py
+++ b/batdetect2/api.py
@@ -250,7 +250,7 @@ def process_file(
     model: DetectionModel = MODEL,
     config: Optional[ProcessingConfiguration] = None,
     device: torch.device = DEVICE,
-    file_id: str | None = None
+    file_id: Optional[str] = None
 ) -> du.RunResults:
     """Process audio file with model.
 
@@ -286,7 +286,7 @@ def process_url(
     model: DetectionModel = MODEL,
     config: Optional[ProcessingConfiguration] = None,
     device: torch.device = DEVICE,
-    file_id: str | None = None
+    file_id: Optional[str] = None
 ) -> du.RunResults:
     """Process audio file with model.
 

--- a/batdetect2/api.py
+++ b/batdetect2/api.py
@@ -99,6 +99,7 @@ consult the API documentation in the code.
 import warnings
 from typing import List, Optional, Tuple, BinaryIO, Any, Union
 
+from .types import AudioPath
 import numpy as np
 import torch
 
@@ -244,9 +245,7 @@ def generate_spectrogram(
 
 
 def process_file(
-    path:  Union[
-        str, int, os.PathLike[Any], sf.SoundFile, audioread.AudioFile, BinaryIO
-    ],
+    path: AudioPath,
     model: DetectionModel = MODEL,
     config: Optional[ProcessingConfiguration] = None,
     device: torch.device = DEVICE,
@@ -256,9 +255,7 @@ def process_file(
 
     Parameters
     ----------
-    path :  Union[
-        str, int, os.PathLike[Any], sf.SoundFile, audioread.AudioFile, BinaryIO
-    ]
+    path : AudioPath
         Path to audio data.
     model : DetectionModel, optional
         Detection model. Uses default model if not specified.

--- a/batdetect2/api.py
+++ b/batdetect2/api.py
@@ -97,7 +97,7 @@ consult the API documentation in the code.
 
 """
 import warnings
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, BinaryIO, Any, Union
 
 import numpy as np
 import torch
@@ -119,6 +119,10 @@ from batdetect2.types import (
     SpectrogramParameters,
 )
 from batdetect2.utils.detector_utils import list_audio_files, load_model
+
+import audioread
+import os 
+import soundfile as sf
 
 # Remove warnings from torch
 warnings.filterwarnings("ignore", category=UserWarning, module="torch")
@@ -238,32 +242,41 @@ def generate_spectrogram(
 
 
 def process_file(
-    audio_file: str,
+    path:  Union[
+        str, int, os.PathLike[Any], sf.SoundFile, audioread.AudioFile, BinaryIO
+    ],
     model: DetectionModel = MODEL,
     config: Optional[ProcessingConfiguration] = None,
     device: torch.device = DEVICE,
+    file_id: str | None = None
 ) -> du.RunResults:
     """Process audio file with model.
 
     Parameters
     ----------
-    audio_file : str
-        Path to audio file.
+    path :  Union[
+        str, int, os.PathLike[Any], sf.SoundFile, audioread.AudioFile, BinaryIO
+    ]
+        Path to audio data.
     model : DetectionModel, optional
         Detection model. Uses default model if not specified.
     config : Optional[ProcessingConfiguration], optional
         Processing configuration, by default None (uses default parameters).
     device : torch.device, optional
         Device to use, by default tries to use GPU if available.
+    file_id: Optional[str],
+        Give the data an id. If path is a string path to a file this can be ignored and
+        the file_id will be the basename of the file.
     """
     if config is None:
         config = CONFIG
 
     return du.process_file(
-        audio_file,
+        path,
         model,
         config,
         device,
+        file_id
     )
 
 

--- a/batdetect2/types.py
+++ b/batdetect2/types.py
@@ -1,6 +1,10 @@
 """Types used in the code base."""
 
-from typing import List, NamedTuple, Optional, Union
+from typing import List, NamedTuple, Optional, Union, Any, BinaryIO
+
+import audioread
+import os 
+import soundfile as sf
 
 import numpy as np
 import torch
@@ -40,6 +44,9 @@ __all__ = [
     "SpectrogramParameters",
 ]
 
+AudioPath =  Union[
+        str, int, os.PathLike[Any], sf.SoundFile, audioread.AudioFile, BinaryIO
+    ]
 
 class SpectrogramParameters(TypedDict):
     """Parameters for generating spectrograms."""

--- a/batdetect2/utils/audio_utils.py
+++ b/batdetect2/utils/audio_utils.py
@@ -185,7 +185,7 @@ def load_audio_data(
     target_samp_rate: int,
     scale: bool = False,
     max_duration: Optional[float] = None,
-) -> Tuple[int, np.ndarray, int | float]:
+) -> Tuple[int, np.ndarray, Union[float, int]]:
     """Load an audio file and resample it to the target sampling rate.
 
     The audio is also scaled to [-1, 1] and clipped to the maximum duration.

--- a/batdetect2/utils/audio_utils.py
+++ b/batdetect2/utils/audio_utils.py
@@ -1,6 +1,8 @@
 import warnings
 from typing import Optional, Tuple, Union, Any, BinaryIO
 
+from ..types import AudioPath
+
 import librosa
 import librosa.core.spectrum
 import numpy as np
@@ -146,9 +148,7 @@ def generate_spectrogram(
     return spec, spec_for_viz
 
 def load_audio(
-    path:  Union[
-        str, int, os.PathLike[Any], sf.SoundFile, audioread.AudioFile, BinaryIO
-    ],
+    path: AudioPath,
     time_exp_fact: float,
     target_samp_rate: int,
     scale: bool = False,
@@ -177,9 +177,7 @@ def load_audio(
     return sample_rate, audio_data
 
 def load_audio_and_samplerate(
-    path:  Union[
-        str, int, os.PathLike[Any], sf.SoundFile, audioread.AudioFile, BinaryIO
-    ],
+    path: AudioPath,
     time_exp_fact: float,
     target_samp_rate: int,
     scale: bool = False,

--- a/batdetect2/utils/audio_utils.py
+++ b/batdetect2/utils/audio_utils.py
@@ -9,6 +9,7 @@ import torch
 import audioread
 import os 
 import soundfile as sf
+import io
 
 from batdetect2.detector import parameters
 
@@ -147,7 +148,10 @@ def generate_spectrogram(
 def get_samplerate(
     path:  Union[
         str, int, os.PathLike[Any], sf.SoundFile, audioread.AudioFile, BinaryIO
-    ]):
+    ]):       
+    if isinstance(path, (BinaryIO, io.BytesIO)):
+        path.seek(0)
+    
     with sf.SoundFile(path) as f:
         return f.samplerate
 

--- a/batdetect2/utils/audio_utils.py
+++ b/batdetect2/utils/audio_utils.py
@@ -9,7 +9,6 @@ import torch
 import audioread
 import os 
 import soundfile as sf
-import io
 
 from batdetect2.detector import parameters
 
@@ -17,7 +16,7 @@ from . import wavfile
 
 __all__ = [
     "load_audio",
-    "load_audio_data",
+    "load_audio_and_samplerate",
     "generate_spectrogram",
     "pad_audio",
 ]
@@ -174,10 +173,10 @@ def load_audio(
         ValueError: If the audio file is stereo.
 
     """
-    sample_rate, audio_data, _ = load_audio_data(path, time_exp_fact, target_samp_rate, scale, max_duration)
+    sample_rate, audio_data, _ = load_audio_and_samplerate(path, time_exp_fact, target_samp_rate, scale, max_duration)
     return sample_rate, audio_data
 
-def load_audio_data(
+def load_audio_and_samplerate(
     path:  Union[
         str, int, os.PathLike[Any], sf.SoundFile, audioread.AudioFile, BinaryIO
     ],
@@ -200,6 +199,7 @@ def load_audio_data(
     Returns:
         sampling_rate: The sampling rate of the audio.
         audio_raw: The audio signal in a numpy array.
+        file_sampling_rate: The original sampling rate of the audio
 
     Raises:
         ValueError: If the audio file is stereo.

--- a/batdetect2/utils/audio_utils.py
+++ b/batdetect2/utils/audio_utils.py
@@ -1,10 +1,14 @@
 import warnings
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union, Any, BinaryIO
 
 import librosa
 import librosa.core.spectrum
 import numpy as np
 import torch
+
+import audioread
+import os 
+import soundfile as sf
 
 from batdetect2.detector import parameters
 
@@ -140,21 +144,29 @@ def generate_spectrogram(
 
     return spec, spec_for_viz
 
+def get_samplerate(
+    path:  Union[
+        str, int, os.PathLike[Any], sf.SoundFile, audioread.AudioFile, BinaryIO
+    ]):
+    with sf.SoundFile(path) as f:
+        return f.samplerate
 
 def load_audio(
-    audio_file: str,
+    path:  Union[
+        str, int, os.PathLike[Any], sf.SoundFile, audioread.AudioFile, BinaryIO
+    ],
     time_exp_fact: float,
     target_samp_rate: int,
     scale: bool = False,
     max_duration: Optional[float] = None,
-) -> Tuple[int, np.ndarray]:
+) -> Tuple[int, np.ndarray ]:
     """Load an audio file and resample it to the target sampling rate.
 
     The audio is also scaled to [-1, 1] and clipped to the maximum duration.
     Only mono files are supported.
 
     Args:
-        audio_file (str): Path to the audio file.
+        path (string, int, pathlib.Path, soundfile.SoundFile, audioread object, or file-like object): path to the input file.
         target_samp_rate (int): Target sampling rate.
         scale (bool): Whether to scale the audio to [-1, 1].
         max_duration (float): Maximum duration of the audio in seconds.
@@ -170,16 +182,16 @@ def load_audio(
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=wavfile.WavFileWarning)
         # sampling_rate, audio_raw = wavfile.read(audio_file)
-        audio_raw, sampling_rate = librosa.load(
-            audio_file,
+        audio_raw, file_sampling_rate = librosa.load(
+            path,
             sr=None,
             dtype=np.float32,
         )
-
+    
     if len(audio_raw.shape) > 1:
         raise ValueError("Currently does not handle stereo files")
 
-    sampling_rate = sampling_rate * time_exp_fact
+    sampling_rate = file_sampling_rate * time_exp_fact
 
     # resample - need to do this after correcting for time expansion
     sampling_rate_old = sampling_rate

--- a/batdetect2/utils/detector_utils.py
+++ b/batdetect2/utils/detector_utils.py
@@ -742,7 +742,7 @@ def process_file(
     model: DetectionModel,
     config: ProcessingConfiguration,
     device: torch.device,
-    file_id: str | None = None
+    file_id: Optional[str] = None
 ) -> Union[RunResults, Any]:
     """Process a single audio file with detection model.
 

--- a/batdetect2/utils/detector_utils.py
+++ b/batdetect2/utils/detector_utils.py
@@ -773,14 +773,13 @@ def process_file(
     spec_slices = []
 
     # load audio file
-    sampling_rate, audio_full = au.load_audio(
+    sampling_rate, audio_full, file_samp_rate = au.load_audio_data(
         path,
         time_exp_fact=config.get("time_expansion", 1) or 1,
         target_samp_rate=config["target_samp_rate"],
         scale=config["scale_raw_audio"],
         max_duration=config.get("max_duration"),
     )
-    file_samp_rate = au.get_samplerate(path)
 
     orig_samp_rate = file_samp_rate * (config.get("time_expansion") or 1)
 

--- a/batdetect2/utils/detector_utils.py
+++ b/batdetect2/utils/detector_utils.py
@@ -2,6 +2,8 @@ import json
 import os
 from typing import Any, Iterator, List, Optional, Tuple, Union, BinaryIO
 
+from ..types import AudioPath
+
 import numpy as np
 import pandas as pd
 import torch
@@ -735,9 +737,7 @@ def process_audio_array(
 
 
 def process_file(
-    path:  Union[
-        str, int, os.PathLike[Any], sf.SoundFile, audioread.AudioFile, BinaryIO
-    ],
+    path: AudioPath,
     model: DetectionModel,
     config: ProcessingConfiguration,
     device: torch.device,
@@ -750,7 +750,7 @@ def process_file(
 
     Parameters
     ----------
-    path : str, int, os.PathLike[Any], sf.SoundFile, audioread.AudioFile, BinaryIO
+    path : AudioPath
         Path to audio file.
 
     model : torch.nn.Module
@@ -760,7 +760,7 @@ def process_file(
         Configuration for processing.
     
     file_id: Optional[str],
-        Give the data an id. Defaults to the filename if path is a string. Otherwise
+        Give the data an id. Defaults to the filename if path is a string. Otherwise an md5 will be calculated from the binary data.
 
     Returns
     -------
@@ -859,9 +859,7 @@ def process_file(
 
     return results
 
-def _generate_id(path:  Union[
-        str, int, os.PathLike[Any], sf.SoundFile, audioread.AudioFile, BinaryIO
-    ]) -> str:
+def _generate_id(path: AudioPath) -> str:
     """ Generate an id based on the path.
     
     If the path is a str or PathLike it will parsed as the basename. 

--- a/batdetect2/utils/detector_utils.py
+++ b/batdetect2/utils/detector_utils.py
@@ -2,7 +2,6 @@ import json
 import os
 from typing import Any, Iterator, List, Optional, Tuple, Union, BinaryIO
 
-import librosa
 import numpy as np
 import pandas as pd
 import torch
@@ -759,6 +758,9 @@ def process_file(
 
     config : ProcessingConfiguration
         Configuration for processing.
+    
+    file_id: Optional[str],
+        Give the data an id. Defaults to the filename if path is a string. Otherwise
 
     Returns
     -------
@@ -773,7 +775,7 @@ def process_file(
     spec_slices = []
 
     # load audio file
-    sampling_rate, audio_full, file_samp_rate = au.load_audio_data(
+    sampling_rate, audio_full, file_samp_rate = au.load_audio_and_samplerate(
         path,
         time_exp_fact=config.get("time_expansion", 1) or 1,
         target_samp_rate=config["target_samp_rate"],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -284,7 +284,7 @@ def test_process_file_with_empty_predictions_does_not_fail(
     assert len(results["pred_dict"]["annotation"]) == 0
 
 def test_process_file_file_id_defaults_to_basename():
-    """Test that no detections are made above the nyquist frequency."""
+    """Test that process_file assigns basename as an id if no file_id is provided."""
     # Recording donated by @@kdarras
     basename = "20230322_172000_selec2.wav"
     path = os.path.join(DATA_DIR, basename)
@@ -295,7 +295,7 @@ def test_process_file_file_id_defaults_to_basename():
     assert id == basename
 
 def test_bytesio_file_id_defaults_to_md5():
-    """Test that no detections are made above the nyquist frequency."""
+    """Test that process_file assigns an md5 sum as an id if no file_id is provided when using binary data."""
     # Recording donated by @@kdarras
     basename = "20230322_172000_selec2.wav"
     path = os.path.join(DATA_DIR, basename)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,11 +10,13 @@ import torch
 from torch import nn
 
 from batdetect2 import api
+import io 
 
 PKG_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TEST_DATA_DIR = os.path.join(PKG_DIR, "example_data", "audio")
 TEST_DATA = glob(os.path.join(TEST_DATA_DIR, "*.wav"))
 
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
 def test_load_model_with_default_params():
     """Test loading model with default parameters."""
@@ -280,3 +282,28 @@ def test_process_file_with_empty_predictions_does_not_fail(
 
     assert results is not None
     assert len(results["pred_dict"]["annotation"]) == 0
+
+def test_process_file_file_id_defaults_to_basename():
+    """Test that no detections are made above the nyquist frequency."""
+    # Recording donated by @@kdarras
+    basename = "20230322_172000_selec2.wav"
+    path = os.path.join(DATA_DIR, basename)
+
+    output = api.process_file(path)
+    predictions = output["pred_dict"]
+    id = predictions["id"]
+    assert id == basename
+
+def test_bytesio_file_id_defaults_to_md5():
+    """Test that no detections are made above the nyquist frequency."""
+    # Recording donated by @@kdarras
+    basename = "20230322_172000_selec2.wav"
+    path = os.path.join(DATA_DIR, basename)
+
+    with open(path, "rb") as f:
+        data = io.BytesIO(f.read())
+
+    output = api.process_file(data)
+    predictions = output["pred_dict"]
+    id = predictions["id"]
+    assert id == "7ade9ebf1a9fe5477ff3a2dc57001929"

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -137,57 +137,20 @@ def test_pad_audio_with_fixed_width(duration: float, width: int):
         resize_factor=params["resize_factor"],
     )
     assert expected_width == width
-
-def test_get_samplerate_using_bytesio():
-    with open("example_data/audio/20170701_213954-MYOMYS-LR_0_0.5.wav", "rb") as f:
-        audio_bytes = io.BytesIO(f.read())
-    
-    sample_rate = audio_utils.get_samplerate(audio_bytes)
-
-    expected_sample_rate = 500000
-    assert expected_sample_rate == sample_rate
-
     
 
-def test_load_audio_using_bytes():
-    filename = "example_data/audio/20170701_213954-MYOMYS-LR_0_0.5.wav"
-    
-    with open(filename, "rb") as f:
-        audio_bytes = io.BytesIO(f.read())
-    
-    sample_rate, audio_data = audio_utils.load_audio(audio_bytes, time_exp_fact=1, target_samp_rate=parameters.TARGET_SAMPLERATE_HZ)
-
-    expected_sample_rate, expected_audio_data = audio_utils.load_audio(filename, time_exp_fact=1, target_samp_rate=parameters.TARGET_SAMPLERATE_HZ)
-
-    assert expected_sample_rate == sample_rate
-
-    assert np.array_equal(audio_data, expected_audio_data)
-
-
-
-def test_get_samplerate_using_bytesio_2():
-    basename = "20230322_172000_selec2.wav"
-    path = os.path.join(DATA_DIR, basename)
-
-    with open(path, "rb") as f:
-        audio_bytes = io.BytesIO(f.read())
-    
-    sample_rate = audio_utils.get_samplerate(audio_bytes)
-
-    expected_sample_rate = 192_000
-    assert expected_sample_rate == sample_rate
-
-def test_load_audio_using_bytes_2():
+def test_load_audio_using_bytesio():
     basename = "20230322_172000_selec2.wav"
     path = os.path.join(DATA_DIR, basename)
 
     with open(path, "rb") as f:
         data = io.BytesIO(f.read())
     
-    sample_rate, audio_data = audio_utils.load_audio(data, time_exp_fact=1, target_samp_rate=parameters.TARGET_SAMPLERATE_HZ)
+    sample_rate, audio_data, file_sample_rate = audio_utils.load_audio_data(data, time_exp_fact=1, target_samp_rate=parameters.TARGET_SAMPLERATE_HZ)
 
-    expected_sample_rate, expected_audio_data = audio_utils.load_audio(path, time_exp_fact=1, target_samp_rate=parameters.TARGET_SAMPLERATE_HZ)
+    expected_sample_rate, expected_audio_data, exp_file_sample_rate = audio_utils.load_audio_data(path, time_exp_fact=1, target_samp_rate=parameters.TARGET_SAMPLERATE_HZ)
 
     assert expected_sample_rate == sample_rate
+    assert exp_file_sample_rate == file_sample_rate
 
     assert np.array_equal(audio_data, expected_audio_data)

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -7,7 +7,9 @@ from hypothesis import strategies as st
 from batdetect2.detector import parameters
 from batdetect2.utils import audio_utils, detector_utils
 import io
-import requests
+import os
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
 @given(duration=st.floats(min_value=0.1, max_value=2))
 def test_can_compute_correct_spectrogram_width(duration: float):
@@ -144,3 +146,48 @@ def test_get_samplerate_using_bytesio():
 
     expected_sample_rate = 500000
     assert expected_sample_rate == sample_rate
+
+    
+
+def test_load_audio_using_bytes():
+    filename = "example_data/audio/20170701_213954-MYOMYS-LR_0_0.5.wav"
+    
+    with open(filename, "rb") as f:
+        audio_bytes = io.BytesIO(f.read())
+    
+    sample_rate, audio_data = audio_utils.load_audio(audio_bytes, time_exp_fact=1, target_samp_rate=parameters.TARGET_SAMPLERATE_HZ)
+
+    expected_sample_rate, expected_audio_data = audio_utils.load_audio(filename, time_exp_fact=1, target_samp_rate=parameters.TARGET_SAMPLERATE_HZ)
+
+    assert expected_sample_rate == sample_rate
+
+    assert np.array_equal(audio_data, expected_audio_data)
+
+
+
+def test_get_samplerate_using_bytesio_2():
+    basename = "20230322_172000_selec2.wav"
+    path = os.path.join(DATA_DIR, basename)
+
+    with open(path, "rb") as f:
+        audio_bytes = io.BytesIO(f.read())
+    
+    sample_rate = audio_utils.get_samplerate(audio_bytes)
+
+    expected_sample_rate = 192_000
+    assert expected_sample_rate == sample_rate
+
+def test_load_audio_using_bytes_2():
+    basename = "20230322_172000_selec2.wav"
+    path = os.path.join(DATA_DIR, basename)
+
+    with open(path, "rb") as f:
+        data = io.BytesIO(f.read())
+    
+    sample_rate, audio_data = audio_utils.load_audio(data, time_exp_fact=1, target_samp_rate=parameters.TARGET_SAMPLERATE_HZ)
+
+    expected_sample_rate, expected_audio_data = audio_utils.load_audio(path, time_exp_fact=1, target_samp_rate=parameters.TARGET_SAMPLERATE_HZ)
+
+    assert expected_sample_rate == sample_rate
+
+    assert np.array_equal(audio_data, expected_audio_data)

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -6,7 +6,8 @@ from hypothesis import strategies as st
 
 from batdetect2.detector import parameters
 from batdetect2.utils import audio_utils, detector_utils
-
+import io
+import requests
 
 @given(duration=st.floats(min_value=0.1, max_value=2))
 def test_can_compute_correct_spectrogram_width(duration: float):
@@ -134,3 +135,11 @@ def test_pad_audio_with_fixed_width(duration: float, width: int):
         resize_factor=params["resize_factor"],
     )
     assert expected_width == width
+
+def test_get_samplerate_using_bytesio():
+    audio_url="https://anon.erda.au.dk/share_redirect/e5c7G2AWmg/F1/20240724/2MU02597/BIOBD01_20240626_231650.wav"
+    
+    sample_rate = audio_utils.get_samplerate(io.BytesIO(requests.get(audio_url).content))
+
+    expected_sample_rate = 256000
+    assert expected_sample_rate == sample_rate

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -137,9 +137,10 @@ def test_pad_audio_with_fixed_width(duration: float, width: int):
     assert expected_width == width
 
 def test_get_samplerate_using_bytesio():
-    audio_url="https://anon.erda.au.dk/share_redirect/e5c7G2AWmg/F1/20240724/2MU02597/BIOBD01_20240626_231650.wav"
+    with open("example_data/audio/20170701_213954-MYOMYS-LR_0_0.5.wav", "rb") as f:
+        audio_bytes = io.BytesIO(f.read())
     
-    sample_rate = audio_utils.get_samplerate(io.BytesIO(requests.get(audio_url).content))
+    sample_rate = audio_utils.get_samplerate(audio_bytes)
 
-    expected_sample_rate = 256000
+    expected_sample_rate = 500000
     assert expected_sample_rate == sample_rate

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -146,9 +146,9 @@ def test_load_audio_using_bytesio():
     with open(path, "rb") as f:
         data = io.BytesIO(f.read())
     
-    sample_rate, audio_data, file_sample_rate = audio_utils.load_audio_data(data, time_exp_fact=1, target_samp_rate=parameters.TARGET_SAMPLERATE_HZ)
+    sample_rate, audio_data, file_sample_rate = audio_utils.load_audio_and_samplerate(data, time_exp_fact=1, target_samp_rate=parameters.TARGET_SAMPLERATE_HZ)
 
-    expected_sample_rate, expected_audio_data, exp_file_sample_rate = audio_utils.load_audio_data(path, time_exp_fact=1, target_samp_rate=parameters.TARGET_SAMPLERATE_HZ)
+    expected_sample_rate, expected_audio_data, exp_file_sample_rate = audio_utils.load_audio_and_samplerate(path, time_exp_fact=1, target_samp_rate=parameters.TARGET_SAMPLERATE_HZ)
 
     assert expected_sample_rate == sample_rate
     assert exp_file_sample_rate == file_sample_rate


### PR DESCRIPTION
Suggestion for implementing support for more ways to load audio data.
This should be backwards compatible.

There is one additional change to the `api.process_file` and `du.process_file` from the once we already discussed.

I've had to add a "file_id" argument. It is optional and uses the basename approach as a fallback if file_id is not provided. The reason is that we cannot get the basename of a byte array.