### PR TITLE
Replace removed np.int alias with int in visualize

### DIFF
--- a/src/batdetect2/utils/visualize.py
+++ b/src/batdetect2/utils/visualize.py
@@ -52,9 +52,9 @@ class InteractivePlotter:
         self.spec_slices = spec_slices
         self.call_info = call_info
         # _, self.labels = np.unique([cc['class'] for cc in call_info], return_inverse=True)
-        self.labels = np.zeros(len(call_info), dtype=np.int)
+        self.labels = np.zeros(len(call_info), dtype=int)
         self.annotated = np.zeros(
-            self.labels.shape[0], dtype=np.int
+            self.labels.shape[0], dtype=int
         )  # can populate this with 1's where we have labels
         self.labels_cols = [
             colors[self.labels[ii]] for ii in range(len(self.labels))

--- a/tests/test_utils/test_visualize.py
+++ b/tests/test_utils/test_visualize.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+from batdetect2.utils.visualize import InteractivePlotter
+
+
+def test_interactive_plotter_init_builds_integer_label_arrays():
+    feats_ds = np.zeros((2, 2))
+    spec_slices = [np.zeros((4, 6)), np.zeros((4, 8))]
+    call_info = [{"class": "a"}, {"class": "b"}]
+
+    plotter = InteractivePlotter(
+        feats_ds=feats_ds,
+        feats=feats_ds,
+        spec_slices=spec_slices,
+        call_info=call_info,
+        freq_lims=[0, 1],
+        allow_training=False,
+    )
+
+    assert plotter.labels.shape == (2,)
+    assert np.issubdtype(plotter.labels.dtype, np.integer)
+    assert np.issubdtype(plotter.annotated.dtype, np.integer)


### PR DESCRIPTION
Creating an `InteractivePlotter` raises `AttributeError: module 'numpy' has no attribute 'int'` on NumPy >= 1.24, which is within the `numpy>=1.23.5` range the project supports. `np.int` was a deprecated alias for the builtin `int` and was removed, so the two `dtype=np.int` uses in `utils/visualize.py` now fail.

Switched both to `dtype=int`, which is the documented behavior-preserving replacement, and added a test that constructs the plotter and checks the label arrays come back as integers.

Fixes #63