### PR TITLE
fix: skip unreadable audio files during batch processing

### DIFF
--- a/src/batdetect2/inference/clips.py
+++ b/src/batdetect2/inference/clips.py
@@ -2,7 +2,9 @@ from typing import List, Sequence
 from uuid import uuid5
 
 import numpy as np
+from loguru import logger
 from soundevent import data
+from soundfile import LibsndfileError
 
 
 def get_clips_from_files(
@@ -16,7 +18,15 @@ def get_clips_from_files(
     clips: List[data.Clip] = []
 
     for path in paths:
-        recording = data.Recording.from_file(path, compute_hash=compute_hash)
+        try:
+            recording = data.Recording.from_file(
+                path,
+                compute_hash=compute_hash,
+            )
+        except LibsndfileError as e:
+            logger.warning(f"Skipping unreadable audio file {path}: {e}")
+            continue
+
         clips.extend(
             get_recording_clips(
                 recording,

--- a/tests/test_cli/test_process.py
+++ b/tests/test_cli/test_process.py
@@ -88,3 +88,44 @@ def test_cli_process_directory_merges_clip_outputs_per_recording(
     )
 
     assert actual_annotations == expected_annotations
+
+
+def test_cli_process_directory_skips_corrupted_files(
+    tmp_path: Path,
+    contrib_dir: Path,
+) -> None:
+    recording_path = contrib_dir / "jeff37" / "0166_20240531_223911.wav"
+
+    source_folder = tmp_path / "audio"
+    source_folder.mkdir()
+    shutil.copy2(
+        recording_path,
+        source_folder / "example_audio.wav",
+    )
+
+    corrupted_file = source_folder / "corrupted.wav"
+    corrupted_file.write_text("corrupted")
+
+    destination_folder = tmp_path / "results"
+    destination_folder.mkdir()
+
+    result = CliRunner().invoke(
+        cli,
+        args=[
+            "process",
+            "directory",
+            str(source_folder),
+            str(destination_folder),
+            "--detection-threshold",
+            "0.3",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert destination_folder.exists()
+
+    output_json = destination_folder / "example_audio.wav.json"
+    assert output_json.exists()
+
+    corrupted_file_json = destination_folder / "corrupted.wav.json"
+    assert not corrupted_file_json.exists()


### PR DESCRIPTION
## Summary

Skip unreadable audio files during batch directory/file-list processing instead
of failing the whole run.

## Changes

- catch `LibsndfileError` when creating recordings in
  `get_clips_from_files`
- log a warning and continue processing the remaining files
- add a CLI regression test covering a directory with one valid file and one
  corrupted file

## Testing

- `uv run pytest tests/test_cli/test_process.py`

## Acknowledgements

Thanks to @SanderBud for raising this in issue #68.